### PR TITLE
feat: Extra parameters for external links through config

### DIFF
--- a/mkdocs_link_marker_plugin/plugin.py
+++ b/mkdocs_link_marker_plugin/plugin.py
@@ -13,24 +13,36 @@ class LinkMarkerPlugin(BasePlugin):
 
         ('enable_mail', config_options.Type(bool, default=True)),
         ('icon_mail', config_options.Type(str, default='✉')),
+
+        ('external_link_parameters', config_options.Type(dict, default={})),
+        ('external_mail_parameters', config_options.Type(dict, default={})),
     )
 
     def __init__(self):
         self.enabled = True
+
+    @staticmethod
+    def build_parameters(parameters):
+        if not parameters:
+            return ''
+    
+        return ' ' + ' '.join([f'{k}={v}' for k, v in parameters.items()])
 
     def on_page_content(self, html, page, config, files):
         if self.config['enable_external_link']:
             p_external_link = re.compile('<a href="(http.*?)">(.*?)</a>')
             def repl_external_link(match):
                 href, content = match.group(1), match.group(2)
+                parameters = self.build_parameters(self.config["external_link_parameters"])
                 # Do not add icon if the content contains an <img> tag
                 if re.search(r'<img\b', content, re.IGNORECASE):
-                    return f'<a href="{href}">{content}</a>'
-                return f'<a href="{href}">{content}&nbsp;{self.config["icon_external_link"]}</a>'
+                    return f'<a href="{href}"{parameters}>{content}</a>'
+                return f'<a href="{href}"{parameters}>{content}&nbsp;{self.config["icon_external_link"]}</a>'
             html = p_external_link.sub(repl_external_link, html)
 
         if self.config['enable_mail']:
             p_mail = re.compile('<a href="(mailto:.*?)">(.*?)</a>')
-            html = p_mail.sub('<a href="\\1">\\2&nbsp;' + self.config['icon_mail'] + '</a>', html)
+            parameters = self.build_parameters(self.config["external_mail_parameters"])
+            html = p_mail.sub(f'<a href="\\1"{parameters}>\\2&nbsp;' + self.config['icon_mail'] + '</a>', html)
 
         return html


### PR DESCRIPTION
This PR introduces the ability to add html attributes to external links via `mkdocs.yml`.

The config `external_link_parameters` adds parameters to external links and `external_mail_parameters` adds parameters to mail links.


## Example

Config:

```yaml mkdocs.yml
plugins:
  - link-marker:
      external_link_parameters:
        rel: '"noopener noreferrer"'
        target: _blank
```


Input Markdown:

```markdown
[Google](https://google.com)
```


Output HTML:

```html
<a href="https://google.com" rel="noopener noreferrer" target="_blank">Google &nbsp;⧉</a>
```