### PR TITLE
feat: Ignore list of URLs to not modify

### DIFF
--- a/mkdocs_link_marker_plugin/plugin.py
+++ b/mkdocs_link_marker_plugin/plugin.py
@@ -13,6 +13,8 @@ class LinkMarkerPlugin(BasePlugin):
 
         ('enable_mail', config_options.Type(bool, default=True)),
         ('icon_mail', config_options.Type(str, default='✉')),
+
+        ('ignore_list', config_options.Type(list, default=[])),
     )
 
     def __init__(self):
@@ -23,6 +25,9 @@ class LinkMarkerPlugin(BasePlugin):
             p_external_link = re.compile('<a href="(http.*?)">(.*?)</a>')
             def repl_external_link(match):
                 href, content = match.group(1), match.group(2)
+                # Do not modify ignored urls
+                if href in self.config['ignore_list']:
+                    return f'<a href="{href}">{content}</a>'
                 # Do not add icon if the content contains an <img> tag
                 if re.search(r'<img\b', content, re.IGNORECASE):
                     return f'<a href="{href}">{content}</a>'


### PR DESCRIPTION
This PR adds the ability to ignore links, thereby not marking them as external.


## Example

Config:

```yaml mkdocs.yml
plugins:
  - link-marker:
      ignore_list:
        - https://duckduckgo.com
```


Input Markdown:

```markdown
- [DuckDuckGo](https://duckduckgo.com)
- [Google](https://google.com)
```


Output HTML:

```html
<a href="https://duckduckgo.com">DuckDuckGo</a>
<a href="https://google.com">Google &nbsp;⧉</a>
```